### PR TITLE
Always use latest intent client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "description": "Library for using the Unify Intent JS Client in a React app.",
   "keywords": [
@@ -30,7 +30,7 @@
     "build": "tsx src/build.ts"
   },
   "dependencies": {
-    "@unifygtm/intent-client": "^0.1.23"
+    "@unifygtm/intent-client": "latest"
   },
   "peerDependencies": {
     "react": "^16.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ specifiers:
   '@babel/preset-typescript': ^7.24.6
   '@types/node': ^18.19.33
   '@types/react': ^18.3.3
-  '@unifygtm/intent-client': ^0.1.23
+  '@unifygtm/intent-client': latest
   babel-core: ^7.0.0-bridge.0
   esbuild: ^0.17.19
   prettier: ^3.2.5
@@ -17,7 +17,7 @@ specifiers:
   typescript: ^5.4.5
 
 dependencies:
-  '@unifygtm/intent-client': 0.1.23
+  '@unifygtm/intent-client': 1.0.1
 
 devDependencies:
   '@babel/cli': 7.24.6_@babel+core@7.24.6
@@ -1767,8 +1767,8 @@ packages:
       csstype: 3.1.3
     dev: true
 
-  /@unifygtm/intent-client/0.1.23:
-    resolution: {integrity: sha512-uq9Y99UAKKOwT9TEcMDjeFIOhch0AbgtXADFbZ24NEuLgnKkO7kpdzQeZK4gx7f+X9VsQ2qbUH+6VxeuHQsPHA==}
+  /@unifygtm/intent-client/1.0.1:
+    resolution: {integrity: sha512-wW8s3Vg8wDxEGVB6BcQGbNlTJJjFurhgcOygjRgrmZ2knAjJjatZ9ffaZtYjE19rGjmbhA0FGrf4aIdMgpa5FA==}
     dependencies:
       js-base64: 3.7.7
       js-cookie: 3.0.5


### PR DESCRIPTION
So we don't need to update this package every time we ship a new version of the client, we can specify that this package should simply always use the latest version of `@unifygtm/intent-client`.