### PR TITLE
Intent react library updates/fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,14 @@ const config: UnifyIntentClientConfig = {
   autoIdentify: false,
 };
 
+const intentClient = new UnifyIntentClient(writeKey, config);
+
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
 );
 
 root.render(
-  <UnifyIntentProvider writeKey={writeKey} config={config}>
+  <UnifyIntentProvider intentClient={intentClient}>
     <App />
   </UnifyIntentProvider>
 );

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ yarn add @unifygtm/intent-react
 Wrap your React app in a `UnifyIntentProvider`:
 
 ```TSX
-import { UnifyIntentProvider, UnifyIntentClientConfig } from '@unifygtm/intent-react';
+import {
+  UnifyIntentClient,
+  UnifyIntentClientConfig,
+  UnifyIntentProvider
+} from '@unifygtm/intent-react';
 
 const writeKey = 'YOUR_PUBLIC_API_KEY';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-react",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Library for using the Unify Intent JS Client in a React app.",
   "keywords": [
     "unify",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-react",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Library for using the Unify Intent JS Client in a React app.",
   "keywords": [
     "unify",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-react",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Library for using the Unify Intent JS Client in a React app.",
   "keywords": [
     "unify",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-react",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Library for using the Unify Intent JS Client in a React app.",
   "keywords": [
     "unify",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-react",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Library for using the Unify Intent JS Client in a React app.",
   "keywords": [
     "unify",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
   "scripts": {
     "build": "tsx src/build.ts"
   },
-  "dependencies": {
-    "@unifygtm/intent-client": "latest"
-  },
   "peerDependencies": {
     "react": "^16.3.0"
   },
@@ -48,5 +45,8 @@
     "prettier": "^3.2.5",
     "tsx": "^4.11.0",
     "typescript": "^5.4.5"
+  },
+  "dependencies": {
+    "@unifygtm/intent-client": "^1.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@unifygtm/intent-client": "^1.0.8"
+    "@unifygtm/intent-client": "^1.0.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-react",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Library for using the Unify Intent JS Client in a React app.",
   "keywords": [
     "unify",
@@ -29,7 +29,7 @@
     "build": "tsx src/build.ts"
   },
   "peerDependencies": {
-    "react": "^16.3.0"
+    "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.24.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-react",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Library for using the Unify Intent JS Client in a React app.",
   "keywords": [
     "unify",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@unifygtm/intent-react",
-  "version": "1.0.1",
-  "type": "module",
+  "version": "1.0.2",
   "description": "Library for using the Unify Intent JS Client in a React app.",
   "keywords": [
     "unify",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-react",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Library for using the Unify Intent JS Client in a React app.",
   "keywords": [
     "unify",
@@ -47,6 +47,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@unifygtm/intent-client": "^1.0.9"
+    "@unifygtm/intent-client": "latest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-react",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Library for using the Unify Intent JS Client in a React app.",
   "keywords": [
     "unify",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ specifiers:
   '@babel/preset-typescript': ^7.24.6
   '@types/node': ^18.19.33
   '@types/react': ^18.3.3
-  '@unifygtm/intent-client': ^1.0.9
+  '@unifygtm/intent-client': latest
   babel-core: ^7.0.0-bridge.0
   esbuild: ^0.17.19
   prettier: ^3.2.5
@@ -17,7 +17,7 @@ specifiers:
   typescript: ^5.4.5
 
 dependencies:
-  '@unifygtm/intent-client': 1.0.9
+  '@unifygtm/intent-client': 1.0.10
 
 devDependencies:
   '@babel/cli': 7.24.6_@babel+core@7.24.6
@@ -1750,6 +1750,10 @@ packages:
     dev: true
     optional: true
 
+  /@types/js-cookie/3.0.6:
+    resolution: {integrity: sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==}
+    dev: false
+
   /@types/node/18.19.33:
     resolution: {integrity: sha512-NR9+KrpSajr2qBVp/Yt5TU/rp+b5Mayi3+OlMlcg2cVCfRmcG5PWZ7S4+MG9PZ5gWBoc9Pd0BKSRViuBCRPu0A==}
     dependencies:
@@ -1767,9 +1771,15 @@ packages:
       csstype: 3.1.3
     dev: true
 
-  /@unifygtm/intent-client/1.0.9:
-    resolution: {integrity: sha512-oa6vJdSKnVnjOJFFkwzHiyWPhnRRV/Ntf/Ot2gzWMaPOy/Hdd5zUzbzvXX2qc93icByDrXfIb8x8MHNBH/0Xcw==}
+  /@types/uuid/9.0.8:
+    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
+    dev: false
+
+  /@unifygtm/intent-client/1.0.10:
+    resolution: {integrity: sha512-9Z610z0R/isUgz82+H1YKBBDt8vSHzz/M0BXezyX4+ypKFYKpCuuvQz9W1ZyxaM/yul0kduhREANrnOEbmnKZQ==}
     dependencies:
+      '@types/js-cookie': 3.0.6
+      '@types/uuid': 9.0.8
       js-base64: 3.7.7
       js-cookie: 3.0.5
       user-agent-data-types: 0.4.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ specifiers:
   '@babel/preset-typescript': ^7.24.6
   '@types/node': ^18.19.33
   '@types/react': ^18.3.3
-  '@unifygtm/intent-client': ^1.0.8
+  '@unifygtm/intent-client': ^1.0.9
   babel-core: ^7.0.0-bridge.0
   esbuild: ^0.17.19
   prettier: ^3.2.5
@@ -17,7 +17,7 @@ specifiers:
   typescript: ^5.4.5
 
 dependencies:
-  '@unifygtm/intent-client': 1.0.8
+  '@unifygtm/intent-client': 1.0.9
 
 devDependencies:
   '@babel/cli': 7.24.6_@babel+core@7.24.6
@@ -1767,8 +1767,8 @@ packages:
       csstype: 3.1.3
     dev: true
 
-  /@unifygtm/intent-client/1.0.8:
-    resolution: {integrity: sha512-XfFMXO+ujvCUqGJSUtIfRXPnHYC3/Z3a7J65EGxfk2j4CBzLe5zlFhxRfnNn9Lzxs3gntCFAUZugRRoyBDkw6A==}
+  /@unifygtm/intent-client/1.0.9:
+    resolution: {integrity: sha512-oa6vJdSKnVnjOJFFkwzHiyWPhnRRV/Ntf/Ot2gzWMaPOy/Hdd5zUzbzvXX2qc93icByDrXfIb8x8MHNBH/0Xcw==}
     dependencies:
       js-base64: 3.7.7
       js-cookie: 3.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ specifiers:
   '@babel/preset-typescript': ^7.24.6
   '@types/node': ^18.19.33
   '@types/react': ^18.3.3
-  '@unifygtm/intent-client': latest
+  '@unifygtm/intent-client': ^1.0.8
   babel-core: ^7.0.0-bridge.0
   esbuild: ^0.17.19
   prettier: ^3.2.5
@@ -17,7 +17,7 @@ specifiers:
   typescript: ^5.4.5
 
 dependencies:
-  '@unifygtm/intent-client': 1.0.1
+  '@unifygtm/intent-client': 1.0.8
 
 devDependencies:
   '@babel/cli': 7.24.6_@babel+core@7.24.6
@@ -1767,8 +1767,8 @@ packages:
       csstype: 3.1.3
     dev: true
 
-  /@unifygtm/intent-client/1.0.1:
-    resolution: {integrity: sha512-wW8s3Vg8wDxEGVB6BcQGbNlTJJjFurhgcOygjRgrmZ2knAjJjatZ9ffaZtYjE19rGjmbhA0FGrf4aIdMgpa5FA==}
+  /@unifygtm/intent-client/1.0.8:
+    resolution: {integrity: sha512-XfFMXO+ujvCUqGJSUtIfRXPnHYC3/Z3a7J65EGxfk2j4CBzLe5zlFhxRfnNn9Lzxs3gntCFAUZugRRoyBDkw6A==}
     dependencies:
       js-base64: 3.7.7
       js-cookie: 3.0.5

--- a/src/UnifyIntentProvider.tsx
+++ b/src/UnifyIntentProvider.tsx
@@ -5,11 +5,11 @@ import {
 import React, { PropsWithChildren, useEffect, useState } from 'react';
 
 interface UnifyIntentContextShape {
-  client: UnifyIntentClient | null;
+  client?: UnifyIntentClient | null;
 }
 
 const defaultContext: UnifyIntentContextShape = {
-  client: null,
+  client: undefined,
 };
 
 export const UnifyIntentContext =

--- a/src/UnifyIntentProvider.tsx
+++ b/src/UnifyIntentProvider.tsx
@@ -2,7 +2,7 @@ import {
   UnifyIntentClient,
   UnifyIntentClientConfig,
 } from '@unifygtm/intent-client';
-import React, { PropsWithChildren, useState } from 'react';
+import React, { PropsWithChildren, useEffect, useState } from 'react';
 
 interface UnifyIntentContextShape {
   client: UnifyIntentClient | null;
@@ -26,9 +26,11 @@ const UnifyIntentProvider = ({
   writeKey,
   config,
 }: UnifyIntentProviderProps) => {
-  const [client] = useState<UnifyIntentClient>(
-    new UnifyIntentClient(writeKey, config),
-  );
+  const [client, setClient] = useState<UnifyIntentClient | null>(null);
+
+  useEffect(() => {
+    setClient(new UnifyIntentClient(writeKey, config));
+  }, []);
 
   return (
     <UnifyIntentContext.Provider value={{ client }}>

--- a/src/UnifyIntentProvider.tsx
+++ b/src/UnifyIntentProvider.tsx
@@ -20,38 +20,20 @@ export type UnifyIntentProviderProps = PropsWithChildren<{
   /**
    * The client instance to make available with this provider.
    */
-  client?: UnifyIntentClient;
-
-  /**
-   * @deprecated - you should pass the `client` prop instead
-   */
-  writeKey?: string;
-
-  /**
-   * @deprecated - you should pass the `client` prop instead
-   */
-  config?: UnifyIntentClientConfig;
+  intentClient: UnifyIntentClient;
 }>;
 
 const UnifyIntentProvider = ({
-  client: clientFromProps,
-  writeKey,
-  config,
+  intentClient,
   children,
 }: UnifyIntentProviderProps) => {
-  const [client, setClient] = useState<UnifyIntentClient | null>(clientFromProps ?? null);
+  const [client] = useState<UnifyIntentClient>(intentClient);
 
   useEffect(() => {
-    if (writeKey) {
-      setClient(new UnifyIntentClient(writeKey, config));
-    } else {
-      client?.mount();
-    }
+      client.mount();
 
     return () => {
-      if (!writeKey) {
-        client?.unmount();
-      }
+      client.unmount();
     }
   }, []);
 

--- a/src/UnifyIntentProvider.tsx
+++ b/src/UnifyIntentProvider.tsx
@@ -1,6 +1,5 @@
 import {
   UnifyIntentClient,
-  UnifyIntentClientConfig,
 } from '@unifygtm/intent-client';
 import React, { PropsWithChildren, useEffect, useState } from 'react';
 

--- a/src/UnifyIntentProvider.tsx
+++ b/src/UnifyIntentProvider.tsx
@@ -5,11 +5,11 @@ import {
 import React, { PropsWithChildren, useEffect, useState } from 'react';
 
 interface UnifyIntentContextShape {
-  client?: UnifyIntentClient | null;
+  client: UnifyIntentClient | null;
 }
 
 const defaultContext: UnifyIntentContextShape = {
-  client: undefined,
+  client: null,
 };
 
 export const UnifyIntentContext =
@@ -17,19 +17,42 @@ export const UnifyIntentContext =
 UnifyIntentContext.displayName = 'UnifyIntentContext';
 
 export type UnifyIntentProviderProps = PropsWithChildren<{
-  writeKey: string;
+  /**
+   * The client instance to make available with this provider.
+   */
+  client?: UnifyIntentClient;
+
+  /**
+   * @deprecated - you should pass the `client` prop instead
+   */
+  writeKey?: string;
+
+  /**
+   * @deprecated - you should pass the `client` prop instead
+   */
   config?: UnifyIntentClientConfig;
 }>;
 
 const UnifyIntentProvider = ({
-  children,
+  client: clientFromProps,
   writeKey,
   config,
+  children,
 }: UnifyIntentProviderProps) => {
-  const [client, setClient] = useState<UnifyIntentClient | null>(null);
+  const [client, setClient] = useState<UnifyIntentClient | null>(clientFromProps ?? null);
 
   useEffect(() => {
-    setClient(new UnifyIntentClient(writeKey, config));
+    if (writeKey) {
+      setClient(new UnifyIntentClient(writeKey, config));
+    } else {
+      client?.mount();
+    }
+
+    return () => {
+      if (!writeKey) {
+        client?.unmount();
+      }
+    }
   }, []);
 
   return (

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-export { UnifyIntentClientConfig } from '@unifygtm/intent-client';
+export { UnifyIntentClientConfig, UnifyIntentClient } from '@unifygtm/intent-client';
 
 export { default as UnifyIntentProvider } from './UnifyIntentProvider';
 export { default as useUnifyIntent } from './useUnifyIntent';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { UnifyIntentClientConfig } from '@unifygtm/intent-client';
+export { UnifyIntentClientConfig, UnifyIntentClient } from '@unifygtm/intent-client';
 
 export { default as UnifyIntentProvider } from './UnifyIntentProvider';
 export { default as useUnifyIntent } from './useUnifyIntent';

--- a/src/useUnifyIntent.ts
+++ b/src/useUnifyIntent.ts
@@ -11,7 +11,7 @@ import { UnifyIntentContext } from './UnifyIntentProvider';
 function useUnifyIntent() {
   const { client } = useContext(UnifyIntentContext);
 
-  if (client === null) {
+  if (client === undefined) {
     throw new Error(
       'useUnifyIntent can only be used within a UnifyIntentProvider.',
     );

--- a/src/useUnifyIntent.ts
+++ b/src/useUnifyIntent.ts
@@ -11,7 +11,7 @@ import { UnifyIntentContext } from './UnifyIntentProvider';
 function useUnifyIntent() {
   const { client } = useContext(UnifyIntentContext);
 
-  if (client === undefined) {
+  if (client === null) {
     throw new Error(
       'useUnifyIntent can only be used within a UnifyIntentProvider.',
     );


### PR DESCRIPTION
This PR updates the intent react library to be compatible with the new method of initializing the intent client, and makes sure to unmount the client when the provider component unmounts.

It also fixes an issue with React peer dependencies.