### PR TITLE
Dependencies bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-react",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Library for using the Unify Intent JS Client in a React app.",
   "keywords": [
     "unify",
@@ -29,7 +29,7 @@
     "build": "tsx src/build.ts"
   },
   "peerDependencies": {
-    "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.24.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-react",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Library for using the Unify Intent JS Client in a React app.",
   "keywords": [
     "unify",
@@ -47,7 +47,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@unifygtm/intent-client": "^1.1.3"
+    "@unifygtm/intent-client": "^1.3.0"
   },
   "pnpm": {
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-react",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Library for using the Unify Intent JS Client in a React app.",
   "keywords": [
     "unify",
@@ -47,7 +47,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@unifygtm/intent-client": "^1.3.0"
+    "@unifygtm/intent-client": "^1.4.0"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@unifygtm/intent-client':
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.4.0
+        version: 1.4.0
       react:
         specifier: ^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
         version: 16.3.0
@@ -970,8 +970,8 @@ packages:
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
-  '@unifygtm/intent-client@1.3.0':
-    resolution: {integrity: sha512-jR0PPqr/oZqSWt4axpCFuE8T//X42FUSDIKk8+kKQeVOwhnrX91FWdk1LZBNyQeX06dIXOyADx7M/jO4Row/hQ==}
+  '@unifygtm/intent-client@1.4.0':
+    resolution: {integrity: sha512-34FW19fvXtyUbhyy9mH7Ycik5yVzjJHCVPchDISg8MIwhx8BzzXYG0ONKUgDrDV5MzZrEM4SYsJBitygAvvC7g==}
 
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -2393,7 +2393,7 @@ snapshots:
 
   '@types/uuid@9.0.8': {}
 
-  '@unifygtm/intent-client@1.3.0':
+  '@unifygtm/intent-client@1.4.0':
     dependencies:
       '@types/js-cookie': 3.0.6
       '@types/uuid': 9.0.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@unifygtm/intent-client':
-        specifier: ^1.1.3
-        version: 1.1.3
+        specifier: ^1.3.0
+        version: 1.3.0
       react:
         specifier: ^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
         version: 16.3.0
@@ -970,8 +970,8 @@ packages:
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
-  '@unifygtm/intent-client@1.1.3':
-    resolution: {integrity: sha512-Be9qAIsVCv7iO/yQTTXcMUUpVPyIuEnVNeiso+8c1BZk+JzxWqclfKF8E7pPM3Wig1zYoXsnZcLdas49VwfF6A==}
+  '@unifygtm/intent-client@1.3.0':
+    resolution: {integrity: sha512-jR0PPqr/oZqSWt4axpCFuE8T//X42FUSDIKk8+kKQeVOwhnrX91FWdk1LZBNyQeX06dIXOyADx7M/jO4Row/hQ==}
 
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -2393,7 +2393,7 @@ snapshots:
 
   '@types/uuid@9.0.8': {}
 
-  '@unifygtm/intent-client@1.1.3':
+  '@unifygtm/intent-client@1.3.0':
     dependencies:
       '@types/js-cookie': 3.0.6
       '@types/uuid': 9.0.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         specifier: ^1.1.3
         version: 1.1.3
       react:
-        specifier: ^16.3.0 || ^17.0.0 || ^18.0.0
+        specifier: ^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
         version: 16.3.0
     devDependencies:
       '@babel/cli':
@@ -1227,6 +1227,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}


### PR DESCRIPTION
1. Allow React 19 as a peer dependency
2. Bump intent client version to newest `1.3.0`