### PR TITLE
Add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Unify
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "name": "Solomon Astley",
     "email": "solomon@unifygtm.com"
   },
-  "license": "UNLICENSED",
+  "license": "MIT",
   "private": false,
   "main": "./dist/js/index.cjs.js",
   "module": "./dist/js/index.esm.js",


### PR DESCRIPTION
## Summary
- Add MIT LICENSE file to the repository
- Update package.json license field from `UNLICENSED` to `MIT`

Please even if you do not want MIT license -- add some sort of license. When people are doing due diligence and we are using this package, they care that we're using a package that's not licensed. 

## Test plan
- [x] LICENSE file contains valid MIT license text
- [x] package.json license field is updated to "MIT"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Formalizes project licensing under MIT.
> 
> - Adds `LICENSE` with standard MIT text
> - Updates `package.json` `license` from `UNLICENSED` to `MIT`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 801068f339bc9a2c87b92a278c13b318a562b207. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->